### PR TITLE
Wrap all StdHook methods

### DIFF
--- a/deepkit/__init__.py
+++ b/deepkit/__init__.py
@@ -64,13 +64,26 @@ if deepkit.utils.in_self_execution():
             log(s)
 
         def __getattr__(self, name):
-            if name == "s":
-                super(StdHook, self).__getattr__(name)
+            """Forward the __getattr__ call to the wrapped object.
+
+            From https://docs.python.org/3/reference/datamodel.html#object.__getattr__:
+            > Note that if the attribute is found through the normal mechanism,
+            > __getattr__() is not called.
+
+            Therefore, `self.s` does not run into a recursion error.
+            """
             return getattr(self.s, name)
 
         def __setattr__(self, name, value):
+            """Set an attribute on the wrapped object.
+
+            Taken from: https://stackoverflow.com/a/17020163/15235649
+
+            Note: `super(StdHook, self).__setattr__` returns the method from
+                  `object.__setattr__.
+            """
             if name == "s":
-                super(StdHook, self).__setattr__(name, value)
+                return super(StdHook, self).__setattr__(name, value)
             return setattr(self.s, name, value)
 
     sys.stdout = StdHook(sys.__stdout__)

--- a/deepkit/__init__.py
+++ b/deepkit/__init__.py
@@ -59,19 +59,19 @@ if deepkit.utils.in_self_execution():
         def __init__(self, s):
             self.s = s
 
-        def fileno(self):
-            return self.s.fileno()
-
-        def isatty(self):
-            return self.s.isatty()
-
-        def flush(self):
-            self.s.flush()
-
         def write(self, s):
             self.s.write(s)
             log(s)
 
+        def __getattr__(self, name):
+            if name == "s":
+                super(StdHook, self).__getattr__(name)
+            return getattr(self.s, name)
+
+        def __setattr__(self, name, value):
+            if name == "s":
+                super(StdHook, self).__setattr__(name, value)
+            return setattr(self.s, name, value)
 
     sys.stdout = StdHook(sys.__stdout__)
     sys.stderr = StdHook(sys.__stderr__)


### PR DESCRIPTION
Hi !

First of all, thanks a lot for this package and for the Deepkit software in general ! We are using it to share experiments internally in our team and it helps a lot :smiley: 

I encountered an issue when trying to debug my code using [pdb](https://docs.python.org/3/library/pdb.html). It has to do with the terminal (stdout) that is catched around the `StdHook` wrapper that logs messages to Deepkit. When I use pdb, I cannot use the arrows to retrieve previous expressions. It is the same issue as described [in this issue](https://github.com/allenai/allennlp/issues/2176) (even though it's a different package and the source of the problem is different).

I have made a workaround to redirect all calls to `StdHook` object to the inner object `self.s`, except for the `write` method which is the one that needs to be overloaded. Maybe this slight improvement can be useful for other people :slightly_smiling_face: